### PR TITLE
Refactor handlers

### DIFF
--- a/alexandria/src/components/app/App.js
+++ b/alexandria/src/components/app/App.js
@@ -6,10 +6,10 @@ import ColorTest from '../common/ColorTest'
 import FrontPageContainer from '../layout/FrontPageContainer'
 import Layout from '../layout/Layout'
 import { Authors } from '../authors'
-import BookList from '../books/BookList'
-import CategoryList from '../categories/CategoryList'
-import LocationList from '../locations/LocationList'
-import PublisherList from '../publishers/PublisherList'
+import { Books } from '../books'
+import { Categories } from '../categories'
+import { Locations } from '../locations'
+import { Publishers } from '../publishers'
 import ReadingsView from '../readings/ReadingsView'
 
 class App extends React.Component {
@@ -18,10 +18,10 @@ class App extends React.Component {
       <Layout>
         <Route exact path='/' render={() => <FrontPageContainer />} />
         <Route exact path='/authors' render={() => <Authors />} />
-        <Route exact path='/books' render={() => <BookList />} />
-        <Route exact path='/categories' render={() => <CategoryList />} />
-        <Route exact path='/locations' render={() => <LocationList />} />
-        <Route exact path='/publishers' render={() => <PublisherList />} />
+        <Route exact path='/books' render={() => <Books />} />
+        <Route exact path='/categories' render={() => <Categories />} />
+        <Route exact path='/locations' render={() => <Locations />} />
+        <Route exact path='/publishers' render={() => <Publishers />} />
         <Route exact path='/readings' render={() => <ReadingsView />} />
         <Route exact path='/colortest' render={() => <ColorTest />} />
       </Layout>

--- a/alexandria/src/components/app/App.js
+++ b/alexandria/src/components/app/App.js
@@ -5,7 +5,7 @@ import './App.css'
 import ColorTest from '../common/ColorTest'
 import FrontPageContainer from '../layout/FrontPageContainer'
 import Layout from '../layout/Layout'
-import AuthorsList from '../authors/AuthorList'
+import { Authors } from '../authors'
 import BookList from '../books/BookList'
 import CategoryList from '../categories/CategoryList'
 import LocationList from '../locations/LocationList'
@@ -17,7 +17,7 @@ class App extends React.Component {
     return (
       <Layout>
         <Route exact path='/' render={() => <FrontPageContainer />} />
-        <Route exact path='/authors' render={() => <AuthorsList />} />
+        <Route exact path='/authors' render={() => <Authors />} />
         <Route exact path='/books' render={() => <BookList />} />
         <Route exact path='/categories' render={() => <CategoryList />} />
         <Route exact path='/locations' render={() => <LocationList />} />

--- a/alexandria/src/components/authors/AuthorList.js
+++ b/alexandria/src/components/authors/AuthorList.js
@@ -15,7 +15,6 @@ import BookEdit from '../books/BookEdit'
 import DeletionConfirmation from '../common/DeletionConfirmation'
 
 function AuthorList(props) {
-  console.log('props', props)
   const [editModalIsOpen, setEditModalIsOpen] = useState(false)
   const [modalViewType, setModalViewType] = useState('Create')
   const [rowToEdit, setRowToEdit] = useState(null)

--- a/alexandria/src/components/authors/Authors.js
+++ b/alexandria/src/components/authors/Authors.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import AuthorList from './AuthorList'
+import withCRUD from '../common/withCRUD'
+import {
+  addAuthor,
+  getAllAuthors,
+  updateAuthor,
+  deleteAuthor
+} from '../../actions/authorActions'
+
+const defaultSort = (a, b) =>
+  a.fullNameReversed > b.fullNameReversed
+    ? 1
+    : (a.fullNameReversed < b.fullNameReversed
+      ? -1
+      : 0)
+
+const Authors = props => {
+  console.log('touch Authors')
+  const Auths = withCRUD(AuthorList)
+  return (
+    <Auths
+      repository={'authors'}
+      defaultSort={defaultSort}
+      addItem={props.addAuthor}
+      getAllItems={props.getAllAuthors}
+      updateItem={props.updateAuthor}
+      deleteItem={props.deleteAuthor}
+    />
+  )
+}
+
+export default connect(
+  null,
+  {
+    addAuthor,
+    getAllAuthors,
+    updateAuthor,
+    deleteAuthor
+  }
+)(Authors)

--- a/alexandria/src/components/authors/Authors.js
+++ b/alexandria/src/components/authors/Authors.js
@@ -17,7 +17,6 @@ const defaultSort = (a, b) =>
       : 0)
 
 const Authors = props => {
-  console.log('touch Authors')
   const Auths = withCRUD(AuthorList)
   return (
     <Auths

--- a/alexandria/src/components/authors/index.js
+++ b/alexandria/src/components/authors/index.js
@@ -1,0 +1,5 @@
+import Authors from './Authors'
+
+export {
+  Authors
+}

--- a/alexandria/src/components/books/Books.js
+++ b/alexandria/src/components/books/Books.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import BookList from './BookList'
+import withCRUD from '../common/withCRUD'
+import {
+  addBook,
+  getAllBooks,
+  updateBook,
+  deleteBook
+} from '../../actions/bookActions'
+
+const defaultSort = (a, b) =>
+  a.title > b.title
+    ? 1
+    : (a.title < b.title
+      ? -1
+      : 0)
+
+const Books = props => {
+  const BooksWrapped = withCRUD(BookList)
+  return (
+    <BooksWrapped
+      repository={'books'}
+      defaultSort={defaultSort}
+      addItem={props.addBook}
+      getAllItems={props.getAllBooks}
+      updateItem={props.updateBook}
+      deleteItem={props.deleteBook}
+    />
+  )
+}
+
+export default connect(
+  null,
+  {
+    addBook,
+    getAllBooks,
+    updateBook,
+    deleteBook
+  }
+)(Books)

--- a/alexandria/src/components/books/index.js
+++ b/alexandria/src/components/books/index.js
@@ -1,0 +1,5 @@
+import Books from './Books'
+
+export {
+  Books
+}

--- a/alexandria/src/components/categories/Categories.js
+++ b/alexandria/src/components/categories/Categories.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import CategoryList from './CategoryList'
+import withCRUD from '../common/withCRUD'
+import {
+  addCategory,
+  getAllCategories,
+  updateCategory,
+  deleteCategory
+} from '../../actions/categoryActions'
+
+const defaultSort = (a, b) =>
+  a.code > b.code
+    ? 1
+    : (a.code < b.code
+      ? -1
+      : 0)
+
+const Categories = props => {
+  const CategoriesWrapped = withCRUD(CategoryList)
+  return (
+    <CategoriesWrapped
+      repository={'categories'}
+      defaultSort={defaultSort}
+      addItem={props.addCategory}
+      getAllItems={props.getAllCategories}
+      updateItem={props.updateCategory}
+      deleteItem={props.deleteCategory}
+    />
+  )
+}
+
+export default connect(
+  null,
+  {
+    addCategory,
+    getAllCategories,
+    updateCategory,
+    deleteCategory
+  }
+)(Categories)

--- a/alexandria/src/components/categories/index.js
+++ b/alexandria/src/components/categories/index.js
@@ -1,0 +1,5 @@
+import Categories from './Categories'
+
+export {
+  Categories
+}

--- a/alexandria/src/components/common/withCRUD.js
+++ b/alexandria/src/components/common/withCRUD.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react'
+import { connect } from 'react-redux'
+import { compose } from 'redux'
+
+const getCRUDs = (WrappedComponent) => props => {
+  const {
+    items,
+    addItem,
+    getAllItems,
+    updateItem,
+    deleteItem
+  } = props
+
+  useEffect(() => {
+    (async function getData() {
+      await getAllItems()
+    })()
+  }, [])
+
+  const [modalError, setModalError] = useState('')
+
+  const handleSave = async (author) => {
+    if (author._id) {
+      await updateItem(author)
+    } else {
+      await addItem(author)
+    }
+    if (props.error) {
+      setModalError('Could not save the author')
+    }
+  }
+
+  const handleDelete = async (itemId) => {
+    await deleteItem(itemId)
+    if (props.error) {
+      setModalError('Could not delete the author')
+    }
+  }
+
+  const showError = error => setModalError(error)
+
+  return (
+    <WrappedComponent
+      items={items}
+      handleSave={handleSave}
+      handleDelete={handleDelete}
+      showError={showError}
+      modalError={modalError}
+    />
+  )
+}
+
+const mapStateToProps = (store, ownProps) => {
+  return {
+    items: store[ownProps.repository].items.sort(ownProps.defaultSort)
+  }
+}
+
+const withCRUD = compose(
+  connect(mapStateToProps, null),
+  getCRUDs
+)
+
+export default withCRUD

--- a/alexandria/src/components/common/withCRUD.js
+++ b/alexandria/src/components/common/withCRUD.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
 
-const getCRUDs = (WrappedComponent) => props => {
+const addCRUDs = (WrappedComponent) => props => {
   const {
     items,
     addItem,
@@ -19,21 +20,21 @@ const getCRUDs = (WrappedComponent) => props => {
 
   const [modalError, setModalError] = useState('')
 
-  const handleSave = async (author) => {
-    if (author._id) {
-      await updateItem(author)
+  const handleSave = async (item) => {
+    if (item._id) {
+      await updateItem(item)
     } else {
-      await addItem(author)
+      await addItem(item)
     }
     if (props.error) {
-      setModalError('Could not save the author')
+      setModalError('Could not save the item')
     }
   }
 
   const handleDelete = async (itemId) => {
     await deleteItem(itemId)
     if (props.error) {
-      setModalError('Could not delete the author')
+      setModalError('Could not delete the item')
     }
   }
 
@@ -58,7 +59,16 @@ const mapStateToProps = (store, ownProps) => {
 
 const withCRUD = compose(
   connect(mapStateToProps, null),
-  getCRUDs
+  addCRUDs
 )
 
 export default withCRUD
+
+withCRUD.propTypes = {
+  repository: PropTypes.string.isRequired,
+  defaultSort: PropTypes.func.isRequired,
+  addItem: PropTypes.func.isRequired,
+  getAllItems: PropTypes.func.isRequired,
+  updateItem: PropTypes.func.isRequired,
+  deleteItem: PropTypes.func.isRequired
+}

--- a/alexandria/src/components/locations/Locations.js
+++ b/alexandria/src/components/locations/Locations.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import LocationList from './LocationList'
+import withCRUD from '../common/withCRUD'
+import {
+  addLocation,
+  getAllLocations,
+  updateLocation,
+  deleteLocation
+} from '../../actions/locationActions'
+
+const defaultSort = (a, b) => a.fullName > b.fullName
+  ? 1
+  : (a.fullName < b.fullName
+    ? -1
+    : 0
+  )
+
+const Locations = props => {
+  const LocationsWrapped = withCRUD(LocationList)
+  return (
+    <LocationsWrapped
+      repository={'locations'}
+      defaultSort={defaultSort}
+      addItem={props.addLocation}
+      getAllItems={props.getAllLocations}
+      updateItem={props.updateLocation}
+      deleteItem={props.deleteLocation}
+    />
+  )
+}
+
+export default connect(
+  null,
+  {
+    addLocation,
+    getAllLocations,
+    updateLocation,
+    deleteLocation
+  }
+)(Locations)

--- a/alexandria/src/components/locations/index.js
+++ b/alexandria/src/components/locations/index.js
@@ -1,0 +1,5 @@
+import Locations from './Locations'
+
+export {
+  Locations
+}

--- a/alexandria/src/components/publishers/Publishers.js
+++ b/alexandria/src/components/publishers/Publishers.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import PublisherList from './PublisherList'
+import withCRUD from '../common/withCRUD'
+import {
+  addPublisher,
+  getAllPublishers,
+  updatePublisher,
+  deletePublisher
+} from '../../actions/publisherActions'
+
+const defaultSort = (a, b) =>
+  a.name > b.name ? 1 : (a.name < b.name ? -1 : 0)
+
+const Publishers = props => {
+  const PublishersWrapped = withCRUD(PublisherList)
+  return (
+    <PublishersWrapped
+      repository={'publishers'}
+      defaultSort={defaultSort}
+      addItem={props.addPublisher}
+      getAllItems={props.getAllPublishers}
+      updateItem={props.updatePublisher}
+      deleteItem={props.deletePublisher}
+    />
+  )
+}
+
+export default connect(
+  null,
+  {
+    addPublisher,
+    getAllPublishers,
+    updatePublisher,
+    deletePublisher
+  }
+)(Publishers)

--- a/alexandria/src/components/publishers/index.js
+++ b/alexandria/src/components/publishers/index.js
@@ -1,0 +1,5 @@
+import Publishers from './Publishers'
+
+export {
+  Publishers
+}


### PR DESCRIPTION
Refactored CRUD-related handlers (and related methods) from `{entity}Lists` (like `AuthorList`) to a generic `withCRUD` HOC and created components named `{entity}s` (like `Authors`) to do the wrapping on` {entity}List` with `withCRUD` and also pass on appropriate entity-specific details to `withCRUD`.